### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/client/coverage/lcov-report/sorter.js
+++ b/client/coverage/lcov-report/sorter.js
@@ -1,4 +1,20 @@
 /* eslint-disable */
+var escapeHTML = function(str) {
+    if (!str) return '';
+    return str.replace(/[&<>"'`=\/]/g, function(s) {
+        return ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+            '`': '&#96;',
+            '=': '&#61;',
+            '/': '&#47;'
+        })[s];
+    });
+};
+
 var addSorting = (function() {
     'use strict';
     var cols,
@@ -88,6 +104,8 @@ var addSorting = (function() {
             val = colNode.getAttribute('data-value');
             if (col.type === 'number') {
                 val = Number(val);
+            } else {
+                val = escapeHTML(val);
             }
             data[col.key] = val;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Markj89/cta-tracker/security/code-scanning/12](https://github.com/Markj89/cta-tracker/security/code-scanning/12)

To fix the issue, we need to sanitize or escape the value retrieved from `colNode.getAttribute('data-value')` before storing it in the `data` object. This ensures that any potentially malicious input is neutralized and cannot be interpreted as executable code or HTML. A simple and effective way to sanitize the value is to use a library like `DOMPurify` or encode the value using a utility function that escapes HTML special characters.

The fix involves:
1. Adding a utility function to escape HTML special characters.
2. Applying this function to the `val` variable before storing it in the `data` object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
